### PR TITLE
Fix: remove method overwriting

### DIFF
--- a/src/markets/capital_goods_market.jl
+++ b/src/markets/capital_goods_market.jl
@@ -21,13 +21,6 @@ function capital_goods_market!(
     random_cap_firms::Vector{<:AbstractCapitalFirm},
     model::AbstractModel,
 )
-    # function body
-end
-function capital_goods_market!(
-    firm::AbstractConsumptionFirm,
-    random_cap_firms::Vector{<:AbstractCapitalFirm},
-    model::AbstractModel,
-)
 
     # amount of liquidity available to buy capital goods
     capital_budget = firm.Ftot + firm.liquidity - firm.Leff * model.agg.wb

--- a/src/model_init/init_agg.jl
+++ b/src/model_init/init_agg.jl
@@ -60,8 +60,3 @@ function initialise_aggregates(params)
     return agg
 
 end
-
-
-function initialise_model(W::Int, F::Int, N::Int, params::Dict)
-    return initialise_model(W, F, N; params = params)
-end


### PR DESCRIPTION
Remove function `capital_goods_market!` and `initialise_model` overwriting.
Overwriting disables pre-compilation when installing the package.